### PR TITLE
small upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,25 @@ pcloud = Pcloud::Client.new(
 pcloud.get("listfolder", folderid: 0)
 ```
 
+Note that, [as per official API docs](https://docs.pcloud.com/):
+
+>pCloud has two data centers. One in United States and one in Europe.
+>As a consequence API calls have to be made to the correct API host name depending were the user has been registered – api.pcloud.com for United States and eapi.pcloud.com for Europe.
+
+The default region used is `https://api.pcloud.com` (US). To use a different region, specify a different `base_url` parameter (EU region: `https://eapi.pcloud.com`) when instantiating a client, e.g.:
+
+```ruby
+require 'pcloud'
+
+pcloud = Pcloud::Client.new(
+  username: 'email',
+  password: 'password',
+  base_url: "https://eapi.pcloud.com",
+).authenticate
+
+pcloud.get("listfolder", folderid: 0)
+```
+
 ### Global configuration
 
 The library can also be configured globally on the `Pcloud` class.

--- a/lib/pcloud/client.rb
+++ b/lib/pcloud/client.rb
@@ -6,11 +6,12 @@ require_relative "./files/file_handler"
 module Pcloud
   class Client
     attr_writer :username, :password
-    attr_accessor :auth_token
+    attr_accessor :auth_token, :base_url
 
     def initialize(options = {})
       @username, @password = options.values_at(:username, :password)
       @auth_token = options[:auth_token]
+      @base_url = options[:base_url] || BASE_URL
     end
 
     def get(path, params={})
@@ -26,7 +27,7 @@ module Pcloud
     end
 
     def http_client
-      @http_client ||= RestClient::Resource.new(BASE_URL)
+      @http_client ||= RestClient::Resource.new(base_url)
     end
 
     def authenticate(options = {})
@@ -37,27 +38,27 @@ module Pcloud
     def request(verb, path, params, payload = {})
       Pcloud::Request.call(self, verb, path, params, payload)
     end
-    
+
   private
     def authorize(options)
       raise ConfigurationError, :username unless @username
       raise ConfigurationError, :password unless @password
-      digest = JSON.parse(RestClient.get("#{BASE_URL}/getdigest"))['digest']
+      digest = JSON.parse(RestClient.get("#{base_url}/getdigest"))['digest']
       passworddigest = digest_data(@password + digest_data( @username.downcase ) + digest)
       [:username, :digest, :passworddigest, :password].each { |k| options.delete(k) }
       params = {params: {
-        username: @username, 
-        digest: digest, 
+        username: @username,
+        digest: digest,
         passworddigest: passworddigest,
         device: "pcloud-ruby",
         getauth: 1
       }.merge!(options)}
-      JSON.parse(RestClient.get("#{BASE_URL}/userinfo", params)) #['auth']
+      JSON.parse(RestClient.get("#{base_url}/userinfo", params)) #['auth']
     end
 
     def digest_data text
       Digest::SHA1.hexdigest(text)
     end
-    
+
   end
 end

--- a/pcloud.gemspec
+++ b/pcloud.gemspec
@@ -17,9 +17,10 @@ Gem::Specification.new do |s|
   s.require_paths         = ["lib".freeze]
   s.required_ruby_version = Gem::Requirement.new(">= 2.3".freeze)
 
-  s.add_dependency "rest-client", "~> 2.0"
-  s.add_dependency "json", "~> 2.6", ">= 2.6.3"
   s.add_dependency "forwardable", "~> 1.3.3"
+  s.add_dependency "json", "~> 2.6", ">= 2.6.3"
+  s.add_dependency "rest-client", "~> 2.0"
+  s.add_dependency "rubyzip", "~> 2.3"
 
   # s.add_development_dependency "rspec", "~> 3.0"
   # s.add_development_dependency "rake", "~> 10.4.2"


### PR DESCRIPTION
* add rubyzip to gemspec, as loading the gem failed without it (or some other gem providing Zip class) outside Rails environment
* allow specifying base_url for EU users, [as per pcloud api documentation](https://docs.pcloud.com/) "API calls have to be made to the correct API host name depending were the user has been registered – api.pcloud.com for United States and eapi.pcloud.com for Europe."